### PR TITLE
feat(application): add ShotOG

### DIFF
--- a/public/assets/data/applications.json
+++ b/public/assets/data/applications.json
@@ -25,5 +25,14 @@
     "properties": {
       "isHobby": true
     }
+  },
+  {
+    "id": "shotog",
+    "name": "ShotOG",
+    "summary": "OG image generation API with 8 templates, batch generation, and custom fonts, running on Cloudflare Workers",
+    "url": "https://github.com/nicepkg/shotog",
+    "properties": {
+      "isHobby": false
+    }
   }
 ]


### PR DESCRIPTION
Hi @yudai-nkt,

I'd like to submit [ShotOG](https://github.com/nicepkg/shotog) to the Applications category.

**ShotOG** is an open-source OG image generation API built with Hono and deployed on Cloudflare Workers. It provides:

- 8 built-in templates for generating OG images
- Batch generation support
- Custom font support
- Simple API interface powered by Hono

It's an actively maintained project, and Hono is at the core of its routing and request handling.

Thank you for maintaining this awesome list!